### PR TITLE
disembed kiraa hat

### DIFF
--- a/CorsacHats.csproj
+++ b/CorsacHats.csproj
@@ -74,20 +74,5 @@
     <Compile Include="MyHats.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="HatSprites\kiraa.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="HatMaker\hatmaker.psd" />
-    <None Include="HatMaker\hatmaker.xcf" />
-    <None Include="README.md" />
-  </ItemGroup>
-  <ItemGroup />
-  <ItemGroup>
-    <Content Include="HatMaker\Examples\Kiraa.hat.png" />
-    <Content Include="HatMaker\Examples\Oggy.hat.png" />
-    <Content Include="HatMaker\Examples\Werella.hat.png" />
-    <Content Include="HatMaker\Examples\Yukia.hat.png" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/MyHats.cs
+++ b/MyHats.cs
@@ -58,15 +58,6 @@ namespace CorsacHats
                 return newHat;
             }
 
-            private static HatBehaviour CreateResourceHat(Assembly assembly, string resourceName)
-            {
-                HatMod.Logger.LogMessage($"Reaching Resource Hat: {resourceName}");
-                var texture = assembly.GetManifestResourceStream(resourceName);
-
-                var nameParts = resourceName.Split('.');
-                return CreateHat(texture, nameParts[nameParts.Length - 2]);
-            }
-
             private static HatBehaviour CreateFilesystemHat(string filePath)
             {
                 HatMod.Logger.LogMessage($"Reaching Filesystem Hat: {filePath}");
@@ -83,23 +74,6 @@ namespace CorsacHats
                     HatMod.Logger.LogError(e.Message);
                     throw e;
                 }
-
-            }
-
-            private static IEnumerable<HatBehaviour> CreateResourceHats()
-            {
-                Assembly assembly = Assembly.GetExecutingAssembly();
-                var resourceNames = assembly.GetManifestResourceNames().Where(n => n.StartsWith("CorsacHats.HatSprites"));
-                if (resourceNames.Count() == 0)
-                {
-                    HatMod.Logger.LogWarning("No Resource Hats found, dumping the full list of resource names");
-                    foreach (var name in assembly.GetManifestResourceNames())
-                    {
-                        HatMod.Logger.LogInfo(name);
-                    }
-                }
-                return resourceNames.Select(name => CreateResourceHat(assembly, name));
-
 
             }
 
@@ -140,16 +114,8 @@ namespace CorsacHats
                 {
                     if (!modded)
                     {
-
-                        HatMod.Logger.LogMessage("Adding resource hats begin");
-                        modded = true;
-                        var hatsFromResoruces = CreateResourceHats();
-                        foreach (var hat in hatsFromResoruces)
-                        {
-                            __instance.AllHats.Add(hat);
-                        }
-
                         HatMod.Logger.LogMessage("Adding filesystem hats");
+                        modded = true;
                         var hatsFromFilesystem = CreateFilesystemHats();
                         foreach (var hat in hatsFromFilesystem)
                         {


### PR DESCRIPTION
considering kiraa.png is already an example hat, players who want it can manually install it. there is no need for it to be embedded in the DLL. in fact, there should be no hats embedded at all, it isn't hard for people to distribute hats if they are making a modded game for friends and are likely handing out the mod DLL anyway.